### PR TITLE
Make gridbot for buy/sell algo

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,6 +62,7 @@ def algorithm(csv_row: str, context: dict[str, Any],):
         response (dict): "Fill"-type object with information for the current and unfilled trades
     
     Yield (None | Trade | [Trade]): a trade order/s; None indicates no trade action
+    Add gridbot algo?
     """
     # algorithm logic...
 


### PR DESCRIPTION
Get average price for BTC/ETH and use buy/sell orders around that value in a grid algo, since we don't have algo yet. idk how to do in python but it would look like
if average = x, buy at x/(constant), sell at x*(constant), and then do the same for the new price?